### PR TITLE
Add JoinColumn annotation to pid of category po

### DIFF
--- a/simter-category-data/src/main/kotlin/tech/simter/category/po/Category.kt
+++ b/simter-category-data/src/main/kotlin/tech/simter/category/po/Category.kt
@@ -18,7 +18,7 @@ data class Category(
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Int?,
   /** Parent Category ID */
-  @ManyToOne(cascade = [(CascadeType.REMOVE)]) val pid: Category?,
+  @ManyToOne(cascade = [(CascadeType.REMOVE)]) @JoinColumn(name = "PID") val pid: Category?,
   /** Status */
   @Convert(converter = CategoryStatusConverter::class) val status: Status,
   /** Name */


### PR DESCRIPTION
补充 JoinColumn 到 Category 的 pid 变量，修正 jpa 转换为原生 SQL 时 category.pid.id 变成 category.pid_id 的问题。